### PR TITLE
Nuget

### DIFF
--- a/tests/Timestamp.E2E.Test/Timestamp.E2E.Test.csproj
+++ b/tests/Timestamp.E2E.Test/Timestamp.E2E.Test.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Timestamp.E2E.Test/Timestamp.E2E.Test.csproj
+++ b/tests/Timestamp.E2E.Test/Timestamp.E2E.Test.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>

--- a/tests/Timestamp.Test/Timestamp.Test.csproj
+++ b/tests/Timestamp.Test/Timestamp.Test.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Timestamp.Test/Timestamp.Test.csproj
+++ b/tests/Timestamp.Test/Timestamp.Test.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>


### PR DESCRIPTION
This pull request updates the test project dependencies to ensure compatibility with the latest tools and improve test reliability. The changes are focused on upgrading the test SDK and test runner packages in both E2E and unit test projects.

Dependency upgrades:

* Upgraded `Microsoft.NET.Test.Sdk` from version 17.14.1 to 18.3.0 in both `Timestamp.E2E.Test.csproj` and `Timestamp.Test.csproj` to use the latest test platform features and fixes. [[1]](diffhunk://#diff-0d9e686b3451f7d095252868d33df1c56d3f049df9fd0c077f757e19e764adadL13-R15) [[2]](diffhunk://#diff-f87c68bd04b0815c489dc9eefd43da0b21035f7643293f01df90b3b1517f5a53L13-R15)
* Updated `xunit.runner.visualstudio` from version 3.1.4 to 3.1.5 in both test project files for improved test runner integration. [[1]](diffhunk://#diff-0d9e686b3451f7d095252868d33df1c56d3f049df9fd0c077f757e19e764adadL13-R15) [[2]](diffhunk://#diff-f87c68bd04b0815c489dc9eefd43da0b21035f7643293f01df90b3b1517f5a53L13-R15)